### PR TITLE
increasing language level in pom to 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,8 +68,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.3.2</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>


### PR DESCRIPTION
after initial checkout 
`mvn compile`
results in
`[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] hollow-reference-implementation/src/main/java/how/hollow/producer/Producer.java:[85,41] error: lambda expressions are not supported in -source 1.7
[INFO] 1 error`

This bumps the source and target versions to Java 8