### PR TITLE
Added missing Maven Jetty dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,13 @@
     </dependency>
 
     <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
+      <version>9.4.2.v20170220</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-s3</artifactId>
       <version>1.11.49</version>


### PR DESCRIPTION
Otherwise you will get the following error when running the consumer.

```
Exception in thread "main" java.lang.ExceptionInInitializerError
	at how.hollow.consumer.Consumer.main(Consumer.java:53)
Caused by: com.netflix.hollow.ui.jetty.OptionalDependencyException: please add jetty-server (org.eclipse.jetty:jetty-server) to your dependencies
	at com.netflix.hollow.ui.jetty.AbstractOptionalDependencyHelper.newFactory(AbstractOptionalDependencyHelper.java:33)
	at com.netflix.hollow.history.ui.jetty.OptionalDependencyHelper.historyUIServerFactory(OptionalDependencyHelper.java:24)
	at com.netflix.hollow.history.ui.jetty.HollowHistoryUIServer.<clinit>(HollowHistoryUIServer.java:26)
	... 1 more
```