### PR TITLE
Hollow 2.6.2 does not appear to be in maven central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,9 +13,9 @@ repositories {
 }
  
 dependencies {
-    compile 'com.netflix.hollow:hollow:2.6.2'
-    compile 'com.netflix.hollow:hollow-diff-ui:2.6.2'
-    compile 'com.netflix.hollow:hollow-explorer-ui:2.6.2'
+    compile 'com.netflix.hollow:hollow:2.6.3'
+    compile 'com.netflix.hollow:hollow-diff-ui:2.6.3'
+    compile 'com.netflix.hollow:hollow-explorer-ui:2.6.3'
     compile 'org.eclipse.jetty:jetty-server:9.4.2.v20170220'
 
     compile 'com.amazonaws:aws-java-sdk-s3:1.11.49'

--- a/pom.xml
+++ b/pom.xml
@@ -14,21 +14,21 @@
     <dependency>
       <groupId>com.netflix.hollow</groupId>
       <artifactId>hollow</artifactId>
-      <version>2.6.2</version>
+      <version>2.6.3</version>
       <scope>compile</scope>
     </dependency>
 
     <dependency>
       <groupId>com.netflix.hollow</groupId>
       <artifactId>hollow-diff-ui</artifactId>
-      <version>2.6.2</version>
+      <version>2.6.3</version>
       <scope>compile</scope>
     </dependency>
 
     <dependency>
       <groupId>com.netflix.hollow</groupId>
       <artifactId>hollow-explorer-ui</artifactId>
-      <version>2.6.2</version>
+      <version>2.6.3</version>
       <scope>compile</scope>
     </dependency>
 


### PR DESCRIPTION
For some reason Hollow 2.6.2 does not appear to be in [maven central](https://repo.maven.apache.org/maven2/com/netflix/hollow/hollow-explorer-ui/) so upgrading to version 2.6.3 which is there.