### PR TITLE
changed java version and added jetty-server dependency to pom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /build/
 /bin/
+/target/
+/.idea/
 .classpath
 .gradle
 .project

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,13 @@
       <version>4.8.2</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
+      <version>9.4.10.v20180503</version>
+    </dependency>
+
   </dependencies>
 
   <build>
@@ -68,8 +75,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.3.2</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>


### PR DESCRIPTION
The java version specified in the POM is 1.7 which doesn't allow for lambdas.  Also, the dependency for jetty-server was missing.

I changed the java version and added the jetty-server dependency to the POM.